### PR TITLE
fix: add missing callback invocation in postAceInit hook

### DIFF
--- a/static/js/rtl.js
+++ b/static/js/rtl.js
@@ -5,4 +5,5 @@ exports.postAceInit = (hookName, args, cb) => {
   $('.popup').addClass('rtl');
   $('input').addClass('rtl');
   pad.changeViewOption('rtlIsTrue', true);
+  return cb();
 };


### PR DESCRIPTION
Found during a systematic audit of all Etherpad plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)