### PR TITLE
fix: stop clobbering URL options + drop redundant .rtl class adds

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -69,4 +69,11 @@ jobs:
           done
           cd src
           pnpm exec playwright install chromium --with-deps
-          pnpm run test-ui --project=chromium
+          # Use the declared-disables helper instead of plain test-ui:
+          # ep.json declares `disables: ["@feature:rtl-toggle"]`, so the
+          # helper runs two passes — regression (everything not tagged
+          # @feature:rtl-toggle must pass) + honesty (every test tagged
+          # @feature:rtl-toggle must FAIL because the plugin genuinely
+          # forces RTL on regardless of URL/cookie). See
+          # doc/PLUGIN_FEATURE_DISABLES.md.
+          ../bin/run-frontend-tests-with-disables.sh -- --project=chromium

--- a/ep.json
+++ b/ep.json
@@ -1,4 +1,5 @@
 {
+  "disables": ["@feature:rtl-toggle"],
   "parts": [
     {
       "name": "right_to_left",

--- a/static/js/rtl.js
+++ b/static/js/rtl.js
@@ -1,9 +1,38 @@
 'use strict';
 
-exports.postAceInit = (hookName, args, cb) => {
-  $('#chattext').addClass('rtl');
-  $('.popup').addClass('rtl');
-  $('input').addClass('rtl');
-  pad.changeViewOption('rtlIsTrue', true);
-  return cb();
+// Force RTL on by default for every pad load.
+//
+// Earlier revision:
+//   $('#chattext').addClass('rtl');
+//   $('.popup').addClass('rtl');
+//   $('input').addClass('rtl');
+//   pad.changeViewOption('rtlIsTrue', true);
+//
+// Two problems with that:
+//
+// 1. pad.changeViewOption('rtlIsTrue', true) re-runs setViewOptions for
+//    *every* option, falling back to defaults for keys that aren't
+//    persisted to pad.padOptions. That clobbered the URL-derived
+//    `?rtl=false` override (rtl_url_param.spec.ts:16) and any other
+//    in-flight option. Same cascade bug fixed in ep_hide_line_numbers.
+//
+// 2. The three .addClass('rtl') calls were dead weight: core's
+//    rtlistrue ace property already does
+//        body.classList.toggle('rtl', value)
+//        document.documentElement.dir = 'rtl'
+//    so direction cascades to every descendant including #chattext,
+//    popups, and inputs. Adding the class manually on top of that
+//    broke two unrelated tests:
+//      - change_user_name.spec.ts uses an exact-match selector
+//        `[class="popup popup-show"]` which never matched once the
+//        plugin appended ` rtl` to the class attribute.
+//      - chat.spec.ts:142 measures left/right padding symmetry on the
+//        chat title bar; flipping just #chattext to rtl (without
+//        flipping the parent) threw the flex centering off by ~170px.
+//
+// Fix: set the ace property directly + sync the settings checkbox.
+// No cascade through setViewOptions, no redundant className mutation.
+exports.postAceInit = (hook, context) => {
+  context.ace.setProperty('rtlistrue', true);
+  $('#options-rtlcheck').prop('checked', true);
 };


### PR DESCRIPTION
## Summary

- Replace `pad.changeViewOption('rtlIsTrue', true)` with `context.ace.setProperty('rtlistrue', true)` + checkbox sync. Same cascade bug pattern fixed recently in ep_hide_line_numbers.
- Drop `$('#chattext')`, `$('.popup')`, `$('input')` `.addClass('rtl')` calls — dead weight since core's `rtlistrue` ace property already toggles `body.rtl` + `documentElement.dir`. Manual class adds were breaking the popup-show exact-match selector and chat title flex symmetry check in unrelated tests.
- Declare `disables: ["@feature:rtl-toggle"]` and switch frontend tests to the helper script so regression + honesty passes both run.

CI green requires ether/etherpad#7661 to merge first (it adds the `@feature:rtl-toggle` tag the helper script keys off).

## Test plan

- [ ] Frontend tests workflow runs both passes via `run-frontend-tests-with-disables.sh`
- [ ] Pass 1: every untagged test passes (chat, change_user_name, error_sanitization, etc. — all previously failing because of the cascade/className bugs)
- [ ] Pass 2: the two `@feature:rtl-toggle` tests fail as expected (plugin genuinely forces RTL on)